### PR TITLE
Allocate stack memory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,13 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "(Windows) Launch ManagerAppQtCamReader",
+            "name": "(Windows) Launch SonicScoutQRScanner",
             "type": "cppvsdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/us/SonicScoutBackend/build_dev/src/ManagerApp/ManagerAppQtCamReader.exe",
+            "program": "${workspaceFolder}/us/SonicScoutBackend/build_dev/src/SonicScout_ManagerApp/SonicScoutQRScanner.exe",
             "args": [],
             "stopAtEntry": true,
-            "cwd": "${workspaceRoot}/us/SonicScoutBackend/build_dev/_CPack_Packages/win64/ZIP/SonicScoutBackend-1.0.0-win64/bin",
+            "cwd": "${workspaceRoot}/us/SonicScoutBackend/5.15.2/msvc2019_64/bin",
             "environment": [],
             "console": "externalTerminal"
         },

--- a/us/SonicScoutBackend/src/SonicScout_ManagerApp/CMakeLists.txt
+++ b/us/SonicScoutBackend/src/SonicScout_ManagerApp/CMakeLists.txt
@@ -47,7 +47,7 @@ if(SONIC_SCOUT_FEATURE_SCANNER)
     add_library(ManagerApp_backend STATIC squirrel_scout_manager.c)
     add_library(SquirrelScout::ManagerApp_backend ALIAS ManagerApp_backend)
     target_link_libraries(ManagerApp_backend
-        PRIVATE DkSDK::OCaml::Compile
+        PRIVATE DkSDK::OCaml::Compile DkSDK::FFI::C-Static
         PUBLIC Threads::Threads
         # The manager app will be a binary that statically links
         # to OCaml (dynamic linking is not required because we


### PR DESCRIPTION
This change, along with using the branch `2025-03-13-firstrobotics-sundome` of dksdk-cmake, were the emergency changes for Sundome 2025 game day to get the scanner working.

The changes in dksdk-cmake ignore the DBUG (debug info) section ... somehow the debug information was corrupt ... and the changes directly in this PR reserve memory for scanner application.